### PR TITLE
chore: Add yaml Lint GitHub Action

### DIFF
--- a/.github/workflows/yamlLint.yaml
+++ b/.github/workflows/yamlLint.yaml
@@ -10,3 +10,8 @@ jobs:
       - uses: actions/checkout@v2
       - name: yaml-lint
         uses: ibiqlik/action-yamllint@v3
+        with:
+          config_data: |
+            extends: default
+            rules:
+              line-length: disable

--- a/.github/workflows/yamlLint.yaml
+++ b/.github/workflows/yamlLint.yaml
@@ -1,0 +1,12 @@
+---
+name: Yaml Lint
+on:
+  pull_request:
+    branches: [develop]
+jobs:
+  lintAllTheThings:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3

--- a/.github/workflows/yamlLint.yaml
+++ b/.github/workflows/yamlLint.yaml
@@ -1,4 +1,3 @@
----
 name: Yaml Lint
 on:
   pull_request:
@@ -7,11 +6,13 @@ jobs:
   lintAllTheThings:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: yaml-lint
-        uses: ibiqlik/action-yamllint@v3
-        with:
-          config_data: |
+    - uses: actions/checkout@v2
+    - name: yaml-lint
+      uses: ibiqlik/action-yamllint@v3
+      with:
+        format: github
+        config_data: |
             extends: default
             rules:
-              line-length: disable
+            line-length: disable
+            document-start: disable

--- a/.github/workflows/yamlLint.yaml
+++ b/.github/workflows/yamlLint.yaml
@@ -1,3 +1,4 @@
+
 name: Yaml Lint
 on:
   pull_request:
@@ -6,13 +7,13 @@ jobs:
   lintAllTheThings:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: yaml-lint
-      uses: ibiqlik/action-yamllint@v3
-      with:
-        format: github
-        config_data: |
+      - uses: actions/checkout@v2
+      - name: yaml-lint
+        uses: ibiqlik/action-yamllint@v3
+        with:
+          format: github
+          config_data: |
             extends: default
             rules:
-            line-length: disable
-            document-start: disable
+              line-length: disable
+              document-start: disable


### PR DESCRIPTION
This GitHub action lints the yaml file for every pull request to the develop branch and prevents a merge if the yaml file is invalid. This removes the extra step of copy pasting & linting on a external website. Proposed here for demo purposes